### PR TITLE
Fix KeyError due to new .json files in exports.

### DIFF
--- a/slack_extract.py
+++ b/slack_extract.py
@@ -21,7 +21,7 @@ class Slack:
             for channel in dirs:
                 self.messages[channel] = {}
             for fname in files:
-                if fname in ["integration_logs.json", "users.json", "channels.json"] or not fname.endswith(".json"):
+                if fname in ["integration_logs.json", "users.json", "channels.json", "file_conversations.json", "canvases.json"] or not fname.endswith(".json"):
                     continue
                 path = os.path.join(subdir, fname)
                 s = path.split("/")


### PR DESCRIPTION
Because Slack now exports more json files at the top level: file_conversations.json and canvases.json,
this line generates the following error:

slack = Slack('s')

KeyError                                  Traceback (most recent call last)
Cell In[2], line 1
----> 1 slack = Slack('s')

File ~/info/ai/rmaiig/slack/slack_extract.py:39, in Slack.__init__(self, data_dir)
     37     m["date"] = date
     38     m["channel"] = cname
---> 39 self.messages[cname][date] = messages

KeyError: 's'

This PR fixes it.
I dare say it would be cleaner to fix it by excluding all top-level json files.